### PR TITLE
remove unneccessary parameter on checkAccount method

### DIFF
--- a/lectures/lecture4/code/beeblog/controllers/category.go
+++ b/lectures/lecture4/code/beeblog/controllers/category.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"beeblog/models"
+
 	"github.com/astaxie/beego"
 )
 
@@ -43,7 +44,7 @@ func (this *CategoryController) Get() {
 
 	this.Data["IsCategory"] = true
 	this.TplNames = "category.html"
-	this.Data["IsLogin"] = checkAccount(this.Ctx, this.Input())
+	this.Data["IsLogin"] = checkAccount(this.Ctx)
 
 	var err error
 	this.Data["Categories"], err = models.GetAllCategories()


### PR DESCRIPTION
我还有一个问题就是我必须要在 models.go 的 AddCategory 方法中为 Category 的 Created, TopicTime 赋初始值 time.Now()， 否则总是报错 NOT NULL constraint failed: category.created. 但是如果我直接运行你的代码的话就没有这个错误信息。我也比较了一下自己敲的代码，没有发现有什么不同。不知道这个是怎么回事。
